### PR TITLE
#16821 add non display fields in system.xml

### DIFF
--- a/Model/Service/SendEmail.php
+++ b/Model/Service/SendEmail.php
@@ -88,7 +88,7 @@ class SendEmail
      */
     private function getMailRecipients(): array
     {
-        $recipientsSerialized = $this->scopeConfig->getValue('fl32_csp/reports/developer_email_csv');
+        $recipientsSerialized = $this->scopeConfig->getValue('fl32_csp/cron/developer_email_csv');
         if (!$recipientsSerialized) {
             throw new EmailSendException('aborted due to missing recepients');
         }
@@ -98,7 +98,7 @@ class SendEmail
 
     private function getMailSenderAddress(): string
     {
-        $mailSenderAddress = $this->scopeConfig->getValue('fl32_csp/reports/report_email_from');
+        $mailSenderAddress = $this->scopeConfig->getValue('fl32_csp/cron/report_email_from');
         if (!$mailSenderAddress) {
             throw new EmailSendException('aborted due to missing email sender address');
         }
@@ -107,7 +107,7 @@ class SendEmail
 
     private function getMailSenderClearName(): string
     {
-        $mailSenderClearName = $this->scopeConfig->getValue('fl32_csp/reports/report_email_from_clear_name');
+        $mailSenderClearName = $this->scopeConfig->getValue('fl32_csp/cron/report_email_from_clear_name');
         if (!$mailSenderClearName) {
             $mailSenderClearName = $this->getMailSenderAddress();
         }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -37,6 +37,21 @@
                         fl32:csp:analyze
                     </tooltip>
                 </field>
+                <field id="developer_email_csv" type="text" translate="label comment" sortOrder="200"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report to Receptients</label>
+                    <comment>Email addresses to which the CSP will report new rules, separate using comma (,)</comment>
+                </field>
+                <field id="report_email_from" type="text" translate="label comment" sortOrder="300"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report from</label>
+                    <comment>Email address from which the CSP reports will be sent</comment>
+                </field>
+                <field id="report_email_from_clear_name" type="text" translate="label comment" sortOrder="400"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report from clear name</label>
+                    <comment>Clear name for sender</comment>
+                </field>
                 <depends>
                     <field id="fl32_csp/general/enabled">1</field>
                 </depends>
@@ -60,21 +75,6 @@
                     <depends>
                         <field id="fl32_csp/reports/developer_only">1</field>
                     </depends>
-                </field>
-                <field id="developer_email_csv" type="text" translate="label comment"
-                       showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Report to Receptients</label>
-                    <comment>Email addresses to which the CSP reports will be sent, separate using comma (,)</comment>
-                </field>
-                <field id="report_email_from" type="text"
-                       showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Report from</label>
-                    <comment>Email address from which the CSP reports will be sent</comment>
-                </field>
-                <field id="report_email_from_clear_name" type="text"
-                       showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Report from clear name</label>
-                    <comment>Clear Name for Report From</comment>
                 </field>
                 <depends>
                     <field id="fl32_csp/general/enabled">1</field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -37,15 +37,6 @@
                         fl32:csp:analyze
                     </tooltip>
                 </field>
-                <field id="developer_email_csv" type="text"
-                       showInDefault="0" showInWebsite="0" showInStore="0">
-                </field>
-                <field id="report_email_from" type="text"
-                       showInDefault="0" showInWebsite="0" showInStore="0">
-                </field>
-                <field id="report_email_from_clear_name" type="text"
-                       showInDefault="0" showInWebsite="0" showInStore="0">
-                </field>
                 <depends>
                     <field id="fl32_csp/general/enabled">1</field>
                 </depends>
@@ -69,6 +60,21 @@
                     <depends>
                         <field id="fl32_csp/reports/developer_only">1</field>
                     </depends>
+                </field>
+                <field id="developer_email_csv" type="text" translate="label comment"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report to Receptients</label>
+                    <comment>Email addresses to which the CSP reports will be sent, separate using comma (,)</comment>
+                </field>
+                <field id="report_email_from" type="text"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report from</label>
+                    <comment>Email address from which the CSP reports will be sent</comment>
+                </field>
+                <field id="report_email_from_clear_name" type="text"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report from clear name</label>
+                    <comment>Clear Name for Report From</comment>
                 </field>
                 <depends>
                     <field id="fl32_csp/general/enabled">1</field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -37,6 +37,15 @@
                         fl32:csp:analyze
                     </tooltip>
                 </field>
+                <field id="developer_email_csv" type="text"
+                       showInDefault="0" showInWebsite="0" showInStore="0">
+                </field>
+                <field id="report_email_from" type="text"
+                       showInDefault="0" showInWebsite="0" showInStore="0">
+                </field>
+                <field id="report_email_from_clear_name" type="text"
+                       showInDefault="0" showInWebsite="0" showInStore="0">
+                </field>
                 <depends>
                     <field id="fl32_csp/general/enabled">1</field>
                 </depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -20,13 +20,13 @@
             </general>
             <cron>
                 <enabled>1</enabled>
+                <developer_email_csv>associateOne@example.com,associateOne@example.com</developer_email_csv>
+                <report_email_from>noreply@example.com</report_email_from>
+                <report_email_from_clear_name>Security Department</report_email_from_clear_name>
             </cron>
             <reports>
                 <developer_only>0</developer_only>
                 <developer_ips>127.0.0.1</developer_ips>
-                <developer_email_csv>associateOne@example.com,associateOne@example.com</developer_email_csv>
-                <report_email_from>noreply@example.com</report_email_from>
-                <report_email_from_clear_name>Security Department</report_email_from_clear_name>
             </reports>
             <rules>
                 <new_rules_active>1</new_rules_active>


### PR DESCRIPTION
added invisible fields to system.xml, enabling the usage of commands
```
bin/magento config:set --lock-config fl32_csp/reports/developer_email_csv security@example.com
bin/magento config:set --lock-config fl32_csp/reports/report_email_from noreply@example.com
bin/magento config:set --lock-config fl32_csp/reports/report_email_from_clear_name "example.com Security"
```